### PR TITLE
Update win_type_global.h

### DIFF
--- a/win_type_global.h
+++ b/win_type_global.h
@@ -54,7 +54,11 @@
 #endif
 
 #ifndef LPCSTR
-    typedef CONST CHAR *LPCSTR, *PCSTR;
+	#ifdef _WINDOWS //uncertain if windows of just MS-C++
+    		typedef CONST CHAR *LPCSTR, *PCSTR;
+ 	#else
+		typedef const CHAR *LPCSTR, *PCSTR; //GCC
+	#endif
 #endif
 
 #ifndef TRACE


### PR DESCRIPTION
Fixed error In file included from CGame.h:36,
                 from CCardRegion.cpp:27:
win_type_global.h:57:13: error: ‘CONST’ does not name a type
   57 |     typedef CONST CHAR *LPCSTR, *PCSTR;
      |             ^~~~~