### PR TITLE
Update cHightScoreMgr.cpp

### DIFF
--- a/cHightScoreMgr.cpp
+++ b/cHightScoreMgr.cpp
@@ -33,11 +33,12 @@
 #include <stdlib.h>
 #ifdef _WINDOWS
 	#include <io.h>
-	#include <sys/stat.h>
-    #include <sys/types.h>
 #else
-    #include <unistd.h>
+    	#include <unistd.h>
 #endif
+
+#include <sys/stat.h> //win & linux
+#include <sys/types.h> //win & linux
 #include <fcntl.h>
 
 


### PR DESCRIPTION
Header is win and linux clears error: cHightScoreMgr.cpp: In member function ‘void cHightScoreMgr::Save()’: cHightScoreMgr.cpp:73:57: error: ‘S_IREAD’ was not declared in this scope
   73 |     f=open("scores.bin",  O_TRUNC | O_WRONLY | O_CREAT, S_IREAD | S_IWRITE   );
      |                                                         ^~~~~~~
cHightScoreMgr.cpp:73:67: error: ‘S_IWRITE’ was not declared in this scope
   73 |     f=open("scores.bin",  O_TRUNC | O_WRONLY | O_CREAT, S_IREAD | S_IWRITE   );
      |                                                                   ^~~~~~~~
make[1]: *** [Makefile:520: cHightScoreMgr.o] Error 1